### PR TITLE
Remove noise

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -31,7 +31,7 @@ router.get(
       ctx.response.headers.set(name, res.headers.get(name)!);
     }
     ctx.response.status = res.status;
-    ctx.response.body = res.body;
+    ctx.response.body = await res.text();
   },
 );
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -33,6 +33,7 @@ router.get(
     ctx.response.headers.set("Cache-Control", "no-cache, max-age=0");
     ctx.response.status = res.status;
     const mimeType = ctx.response.headers.get("Content-Type") ?? "text/plain";
+    console.log({ mimeType });
     ctx.response.body = mimeType.startsWith("image")
       ? res.body
       : await res.text();

--- a/api/index.ts
+++ b/api/index.ts
@@ -30,8 +30,12 @@ router.get(
 
       ctx.response.headers.set(name, res.headers.get(name)!);
     }
+    ctx.response.headers.set("Cache-Control", "no-cache, max-age=0");
     ctx.response.status = res.status;
-    ctx.response.body = await res.text();
+    const mimeType = ctx.response.headers.get("Content-Type") ?? "text/plain";
+    ctx.response.body = mimeType.startsWith("image")
+      ? res.body
+      : await res.text();
   },
 );
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -11,7 +11,25 @@ router.get(
       ...req,
     });
     console.log(`fetched.`);
-    ctx.response.headers = res.headers;
+    const debugLines = (await res.clone().text()).split("\n");
+    console.log([debugLines.at(0), "...", debugLines.at(-1)]);
+    for (
+      const name of [
+        "Content-Type",
+        "X-Content-Type-Options",
+        "X-Frame-Options",
+        "Date",
+        "Etag",
+        "Vary",
+        "Via",
+        "X-This-Is-Not-A-Vulnerability",
+        "Strict-Transport-Security",
+      ]
+    ) {
+      if (!res.headers.has(name)) continue;
+
+      ctx.response.headers.set(name, res.headers.get(name)!);
+    }
     ctx.response.status = res.status;
     ctx.response.body = res.body;
   },

--- a/api/index.ts
+++ b/api/index.ts
@@ -11,8 +11,6 @@ router.get(
       ...req,
     });
     console.log(`fetched.`);
-    const debugLines = (await res.clone().text()).split("\n");
-    console.log([debugLines.at(0), "...", debugLines.at(-1)]);
     for (
       const name of [
         "Content-Type",


### PR DESCRIPTION
一部のJSON/text系APIをfetchした時に、データの先頭と末尾に謎の数値が混入してしまう
- e.g. https://scrapbox-proxy-3xenz3ibg-takker99.vercel.app/api/pages/takker

`res.body`ではなく`await res.text()`を使い、さらにコピーするheadersを絞ることで一応解決できた。

しかし今度はアイコンデータが壊れてしまうバグが発生してしまった
- (before breaking) https://scrapbox-proxy-3xenz3ibg-takker99.vercel.app/api/pages/takker/takker/icon

今のところアイコンを使う予定はないので、放置する